### PR TITLE
RHCOS: Add rhel-coreos and rhel-coreos-extensions keys

### DIFF
--- a/validator/json_schemas/rhcos.schema.json
+++ b/validator/json_schemas/rhcos.schema.json
@@ -61,6 +61,24 @@
     "rhel-coreos-8-extensions?": {
       "$ref": "#/properties/machine-os-content"
     },
+    "rhel-coreos": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos!": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos?": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos-extensions": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos-extensions!": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos-extensions?": {
+      "$ref": "#/properties/machine-os-content"
+    },
     "dependencies": {
       "$ref": "assembly_dependencies.schema.json"
     },


### PR DESCRIPTION
Those RHCOS tags are used in 4.13+.