### PR TITLE
finally fix CA trust issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ jeepney==0.4.3
 jsonschema ~= 4.0.0
 keyring==21.2.1
 packaging==20.4
+pip_system_certs==4.0
 pkginfo==1.5.0.1
 pluggy==0.13.1
 py==1.8.1

--- a/validator/distgit.py
+++ b/validator/distgit.py
@@ -13,7 +13,7 @@ def validate(file, data, group_cfg):
     repo_url = f'git://{distgit_host}/{namespace}/{repository}.git'
     branch = support.get_distgit_branch(data, group_cfg)
 
-    if not support.resource_is_reachable(f'http://{distgit_host}'):
+    if not support.resource_is_reachable(f'https://{distgit_host}/cgit'):
         return repo_url, f'This validation must run from a network with access to {distgit_host}'
 
     repo_dir = TemporaryDirectory()


### PR DESCRIPTION
pkgs.devel now redirects http to https (which is right) so we need tls connections to work. all it needs to work is to trust the system-trusted CA certs. this patches `requests` to do that.