### PR TITLE
Fix TypeError "unexpected keyword argument method_whitelist"

### DIFF
--- a/validator/global_session.py
+++ b/validator/global_session.py
@@ -7,7 +7,7 @@ request_session = None
 retry_strategy = Retry(
     total=3,
     status_forcelist=[429, 500, 502, 503, 504],
-    method_whitelist=["HEAD", "GET", "OPTIONS"]
+    allowed_methods=["HEAD", "GET", "OPTIONS"]
 )
 adapter = HTTPAdapter(max_retries=retry_strategy)
 


### PR DESCRIPTION
It has been renamed to allowed_methods since urllib3 1.26.0.

Error example: https://github.com/openshift-eng/ocp-build-data/pull/3207