### PR TITLE
Print concise error message

### DIFF
--- a/validator/schema/image_schema.py
+++ b/validator/schema/image_schema.py
@@ -25,4 +25,4 @@ def validate(file, data):
         # TODO: Check if the base images referenced in `from` field exist
     except ValidationError:
         errors = validator.iter_errors(data)
-        return '\n\n'.join([str(e) for e in errors])
+        return '\n'.join([str(e.message) for e in errors])

--- a/validator/schema/releases_schema.py
+++ b/validator/schema/releases_schema.py
@@ -54,4 +54,4 @@ def validate(_, data):
         validator.validate(demerged_data)
     except ValidationError:
         errors = validator.iter_errors(demerged_data)
-        return '\n'.join([str(e) for e in errors])
+        return '\n'.join([str(e.message) for e in errors])


### PR DESCRIPTION
Do not print the whole error message which includes schema and image yml, since 
we are posting the output to PR comments - we only need a concise error about which
property is at fault

```
$ ocp-build-data-validator ../ocp-build-data/images/operator-lifecycle-manager.yml
Validating 1 file(s)...
Validating ../ocp-build-data/images/operator-lifecycle-manager.yml...
Schema mismatch: ../ocp-build-data/images/operator-lifecycle-manager.yml
Returned error: Additional properties are not allowed ('envs' was unexpected)

```