### PR TITLE
Use envs instead of env in image config

### DIFF
--- a/validator/json_schemas/image_config.base.schema.json
+++ b/validator/json_schemas/image_config.base.schema.json
@@ -158,7 +158,7 @@
       "$ref": "#/properties/distgit"
     },
     "distgit-": {},
-    "env": {
+    "envs": {
       "type": "object",
       "patternProperties": {
         "^.+$": {
@@ -167,13 +167,13 @@
       },
       "additionalProperties": false
     },
-    "env!": {
-      "$ref": "#/properties/env"
+    "envs!": {
+      "$ref": "#/properties/envs"
     },
-    "env?": {
-      "$ref": "#/properties/env"
+    "envs?": {
+      "$ref": "#/properties/envs"
     },
-    "env-": {},
+    "envs-": {},
     "final_stage_user": {
       "description": "When doozer injects USER 0 to do a yum update, this field instructs doozer to set this user afterwards in the final stage of the build.",
       "oneOf": [


### PR DESCRIPTION
As that is [what is
consumed](https://github.com/openshift-eng/art-tools/blob/9d03553e8e98affd84d23b3bb99af201a9722adc/doozer/doozerlib/distgit.py#L1849)