### PR TITLE
Require regular expression for github branch

### DIFF
--- a/tests/test_schema/test_image_schema.py
+++ b/tests/test_schema/test_image_schema.py
@@ -45,7 +45,7 @@ class TestImageSchema(unittest.TestCase):
                 'source': {
                     'git': {
                         'branch': {
-                            'target': 'test',
+                            'target': 'openshift-{MAJOR}-{MINOR}',
                         },
                         'url': url
                     }

--- a/validator/json_schemas/image_content.base.schema.json
+++ b/validator/json_schemas/image_content.base.schema.json
@@ -232,7 +232,7 @@
               "properties": {
                 "target": {
                   "type": "string",
-                  "minLength": 1
+                  "pattern": "^(openshift|release|enterprise)-({MAJOR}.{MINOR}|base-(nodejs|nodejs-runtime|python|ruby|elasticsearch|jboss|rhel[789]))$"
                 },
                 "target?": {
                   "$ref": "#/properties/source/properties/git/properties/branch/properties/target"


### PR DESCRIPTION
There has been an incident where we unnoticedly configured an image to follow master. This has led to some pain. Requiring the branch to follow a regex prevents us to make the same mistake again.