### PR TITLE
Revert "Require regular expression for github branch"

### DIFF
--- a/tests/test_schema/test_image_schema.py
+++ b/tests/test_schema/test_image_schema.py
@@ -45,7 +45,7 @@ class TestImageSchema(unittest.TestCase):
                 'source': {
                     'git': {
                         'branch': {
-                            'target': 'openshift-{MAJOR}-{MINOR}',
+                            'target': 'test',
                         },
                         'url': url
                     }

--- a/validator/json_schemas/assembly_issues.schema.json
+++ b/validator/json_schemas/assembly_issues.schema.json
@@ -49,5 +49,6 @@
     },
     "exclude-": {},
     "additionalProperties": false
-  }
+  },
+  "additionalProperties": false
 }

--- a/validator/json_schemas/image_content.base.schema.json
+++ b/validator/json_schemas/image_content.base.schema.json
@@ -232,7 +232,7 @@
               "properties": {
                 "target": {
                   "type": "string",
-                  "pattern": "^(openshift|release|enterprise)-({MAJOR}.{MINOR}|base-(nodejs|nodejs-runtime|python|ruby|elasticsearch|jboss|rhel[789]))$"
+                  "minLength": 1
                 },
                 "target?": {
                   "$ref": "#/properties/source/properties/git/properties/branch/properties/target"


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data-validator#121

branch target can be a commit, see https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.11/releases.yml#L372