### PR TITLE
Revert "Add `why` field to assembly issues"

### DIFF
--- a/validator/json_schemas/assembly_issues.schema.json
+++ b/validator/json_schemas/assembly_issues.schema.json
@@ -22,17 +22,11 @@
                 "type": "integer"
               }
             ]
-          },
-          "why": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The reason why this issue should be listed. Note this text is public. Don't include customer related or confidential information."
           }
         },
         "additionalProperties": false,
         "required": [
-          "id",
-          "why"
+          "id"
         ]
       }
     },


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data-validator#107

Before  merging let's plan on making releases.yml consistent with this change, otherwise PR validation is all but useless